### PR TITLE
Use path.sep

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,8 +96,8 @@ LoadRoutes.prototype.pathToRoute = function(target, base) {
   if (base && typeof base === 'string') {
     var segments = [], segment;
 
-    target = target.split('/');
-    base   = path.normalize(base).split('/');
+    target = target.split(path.sep);
+    base   = path.normalize(base).split(path.sep);
     base   = base[base.length - 1];
 
     for (var i = target.length - 1; i >= 0; i--) {


### PR DESCRIPTION
The path separator was hard coded to '/' which meant this does not work on Windows OS. Replaced with path.sep so it will work on any OS.
